### PR TITLE
Updates to support webtrees 1.7.x

### DIFF
--- a/module.php
+++ b/module.php
@@ -284,7 +284,7 @@ class FacebookModule extends AbstractModule implements ModuleConfigInterface, Mo
                 try {
                     Session::forget('facebook_access_token');
                     Session::forget('facebook_state');
-                } catch (Exception $e) { echo "oh snap"; }
+                } catch (Exception $e) { }
 
                 header("Location: " . $this->getConnectURL($url));
                 exit;
@@ -643,7 +643,7 @@ $(document).ready(function() {
         try {
             Session::forget('facebook_access_token');
             Session::forget('facebook_state');
-        } catch (Exception $e) { echo 'huh what'; }
+        } catch (Exception $e) { }
 
         $controller = new PageController();
         $controller

--- a/module.php
+++ b/module.php
@@ -23,71 +23,82 @@ if (!defined('WT_WEBTREES')) {
 
 define('WT_FACEBOOK_VERSION', "v1.0-beta.7");
 define('WT_FACEBOOK_UPDATE_CHECK_URL', "https://api.github.com/repos/mnoorenberghe/webtrees-facebook/contents/versions.json?ref=gh-pages");
+define('WT_REGEX_ALPHA', '[a-zA-Z]+');
+define('WT_REGEX_ALPHANUM', '[a-zA-Z0-9]+');
+define('WT_REGEX_USERNAME', '[^<>"%{};]+');
 
-use WT\Auth;
-use WT\Log;
-use WT\User;
+use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Controller\PageController;
+use Fisharebest\Webtrees\Database;
+use Fisharebest\Webtrees\File;
+use Fisharebest\Webtrees\Filter;
+use Fisharebest\Webtrees\FlashMessages;
+use Fisharebest\Webtrees\Functions\FunctionsEdit;
+use Fisharebest\Webtrees\Functions\FunctionsPrint;
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Log;
+use Fisharebest\Webtrees\Menu;
+use Fisharebest\Webtrees\Module;
+use Fisharebest\Webtrees\Session;
+use Fisharebest\Webtrees\Site;
+use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\User;
+use Fisharebest\Webtrees\Module\AbstractModule;
+use Fisharebest\Webtrees\Module\ModuleConfigInterface;
+use Fisharebest\Webtrees\Module\ModuleMenuInterface;
 
-class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Module_Menu {
+class FacebookModule extends AbstractModule implements ModuleConfigInterface, ModuleMenuInterface {
     const scope = 'user_birthday,user_hometown,user_location,user_relationships,user_relationship_details,email';
     const user_setting_facebook_username = 'facebook_username';
     const profile_photo_large_width = 1024;
     const api_dir = "v1.0/"; // TODO: make an admin preference so new installs can use this module.
 
+    var $directory;
+    
     private $hideStandardForms = false;
-
+        
     public function __construct() {
-        parent::__construct();
+        parent::__construct('facebook');
 
-        // Load any local user translations
-        if (is_dir(WT_MODULES_DIR . $this->getName() . '/language')) {
-            if (file_exists(WT_MODULES_DIR . $this->getName() . '/language/' . WT_LOCALE . '.mo')) {
-                $tr = new Zend_Translate('gettext', WT_MODULES_DIR . $this->getName() . '/language/'
-                                         . WT_LOCALE . '.mo', WT_LOCALE);
-                Zend_Registry::get('Zend_Translate')->addTranslation($tr);
-            }
-        }
+        $this->directory = WT_MODULES_DIR . $this->getName();
     }
 
     // Implement WT_Module_Config
     public function getConfigLink() {
-        return 'module.php?mod='.$this->getName().'&amp;mod_action=admin';
+        return 'module.php?mod=' . $this->getName() . '&amp;mod_action=admin';
     }
 
     // Extend WT_Module
     public function getTitle() {
-        return /* I18N: Name of a module */ WT_I18N::translate('Facebook');
+        return /* I18N: Name of a module */ I18N::translate('Facebook');
     }
 
     // Extend WT_Module
     public function getDescription() {
-        return /* I18N: Description of the "Facebook" module */ WT_I18N::translate('Allow users to login with Facebook.');
+        return /* I18N: Description of the "Facebook" module */ I18N::translate('Allow users to login with Facebook.');
     }
 
     // Extend WT_Module
     public function modAction($mod_action) {
         switch($mod_action) {
             case 'admin':
-                $this->admin();
-                break;
-	    case 'connect':
-                $this->connect();
-                break;
+                return $this->admin();
+            case 'connect':
+                return $this->connect();
             case 'admin_friend_picker':
-                $this->fetchFriendList();
-                break;
-	    default:
+                return $this->fetchFriendList();
+            default:
                 header('HTTP/1.0 404 Not Found');
         }
     }
 
     private function get_edit_options() {
         return array( // from admin_users.php
-                     'none'  => /* I18N: Listbox entry; name of a role */ WT_I18N::translate('Visitor'),
-                     'access'=> /* I18N: Listbox entry; name of a role */ WT_I18N::translate('Member'),
-                     'edit'  => /* I18N: Listbox entry; name of a role */ WT_I18N::translate('Editor'),
-                     'accept'=> /* I18N: Listbox entry; name of a role */ WT_I18N::translate('Moderator'),
-                     'admin' => /* I18N: Listbox entry; name of a role */ WT_I18N::translate('Manager')
+                     'none'  => /* I18N: Listbox entry; name of a role */ I18N::translate('Visitor'),
+                     'access'=> /* I18N: Listbox entry; name of a role */ I18N::translate('Member'),
+                     'edit'  => /* I18N: Listbox entry; name of a role */ I18N::translate('Editor'),
+                     'accept'=> /* I18N: Listbox entry; name of a role */ I18N::translate('Moderator'),
+                     'admin' => /* I18N: Listbox entry; name of a role */ I18N::translate('Manager')
                       );
     }
 
@@ -95,16 +106,16 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
         $mod_name = $this->getName();
         $preApproved = unserialize($this->getSetting('preapproved'));
 
-        if (WT_Filter::post('saveAPI') && WT_Filter::checkCsrf()) {
-            $this->setSetting('app_id', WT_Filter::post('app_id', WT_REGEX_ALPHANUM));
-            $this->setSetting('app_secret', WT_Filter::post('app_secret', WT_REGEX_ALPHANUM));
-            $this->setSetting('require_verified', WT_Filter::post('require_verified', WT_REGEX_INTEGER, false));
-            $this->setSetting('hide_standard_forms', WT_Filter::post('hide_standard_forms', WT_REGEX_INTEGER, false));
+        if (Filter::post('saveAPI') && Filter::checkCsrf()) {
+            $this->setSetting('app_id', Filter::post('app_id', WT_REGEX_ALPHANUM));
+            $this->setSetting('app_secret', Filter::post('app_secret', WT_REGEX_ALPHANUM));
+            $this->setSetting('require_verified', Filter::post('require_verified', WT_REGEX_INTEGER, false));
+            $this->setSetting('hide_standard_forms', Filter::post('hide_standard_forms', WT_REGEX_INTEGER, false));
             Log::addConfigurationLog("Facebook: API settings changed");
-            WT_FlashMessages::addMessage(WT_I18N::translate('Settings saved'));
-        } else if (WT_Filter::post('addLink') && WT_Filter::checkCsrf()) {
-            $user_id = WT_Filter::post('user_id', WT_REGEX_INTEGER);
-            $facebook_username = $this->cleanseFacebookUsername(WT_Filter::post('facebook_username', WT_REGEX_USERNAME));
+            FlashMessages::addMessage(I18N::translate('Settings saved'));
+        } else if (Filter::post('addLink') && Filter::checkCsrf()) {
+            $user_id = Filter::post('user_id', WT_REGEX_INTEGER);
+            $facebook_username = $this->cleanseFacebookUsername(Filter::post('facebook_username', WT_REGEX_USERNAME));
             if ($user_id && $facebook_username && !$this->get_user_id_from_facebook_username($facebook_username)) {
                 $user = User::find($user_id);
                 $user->setPreference(self::user_setting_facebook_username, $facebook_username);
@@ -114,29 +125,29 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
                     $this->setSetting('preapproved', serialize($preApproved));
                 }
                 Log::addConfigurationLog("Facebook: User $user_id linked to Facebook user $facebook_username");
-                WT_FlashMessages::addMessage(WT_I18N::translate('User %1$s linked to Facebook user %2$s', $user_id, $facebook_username));
+                FlashMessages::addMessage(I18N::translate('User %1$s linked to Facebook user %2$s', $user_id, $facebook_username));
             } else {
-                WT_FlashMessages::addMessage(WT_I18N::translate('The user could not be linked'));
+                FlashMessages::addMessage(I18N::translate('The user could not be linked'));
             }
-        } else if (WT_Filter::post('deleteLink') && WT_Filter::checkCsrf()) {
-            $user_id = WT_Filter::post('deleteLink', WT_REGEX_INTEGER);
+        } else if (Filter::post('deleteLink') && Filter::checkCsrf()) {
+            $user_id = Filter::post('deleteLink', WT_REGEX_INTEGER);
             if ($user_id) {
                 $user = User::find($user_id);
                 $user->deletePreference(self::user_setting_facebook_username);
                 Log::addConfigurationLog("Facebook: User $user_id unlinked from a Facebook user");
-                WT_FlashMessages::addMessage(WT_I18N::translate('User unlinked'));
+                FlashMessages::addMessage(I18N::translate('User unlinked'));
             } else {
-                WT_FlashMessages::addMessage(WT_I18N::translate('The link could not be deleted'));
+                FlashMessages::addMessage(I18N::translate('The link could not be deleted'));
             }
-        } else if (WT_Filter::post('savePreapproved') && WT_Filter::checkCsrf()) {
-            $table = WT_Filter::post('preApproved');
-            if ($facebook_username = $this->cleanseFacebookUsername(WT_Filter::post('preApproved_new_facebook_username', WT_REGEX_USERNAME))) {
+        } else if (Filter::post('savePreapproved') && Filter::checkCsrf()) {
+            $table = Filter::post('preApproved');
+            if ($facebook_username = $this->cleanseFacebookUsername(Filter::post('preApproved_new_facebook_username', WT_REGEX_USERNAME))) {
                 // Process additions
                 $row = $table['new'];
                 $this->appendPreapproved($preApproved, $facebook_username, $row);
                 $this->setSetting('preapproved', serialize($preApproved));
                 Log::addConfigurationLog("Facebook: Pre-approved Facebook user: $facebook_username");
-                WT_FlashMessages::addMessage(WT_I18N::translate('Pre-approved user "%s" added', $facebook_username));
+                FlashMessages::addMessage(I18N::translate('Pre-approved user "%s" added', $facebook_username));
             }
             unset($table['new']);
             // Process changes
@@ -145,22 +156,22 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
             }
             $this->setSetting('preapproved', serialize($preApproved));
             Log::addConfigurationLog("Facebook: Pre-approved Facebook users changed");
-            WT_FlashMessages::addMessage(WT_I18N::translate('Changes to pre-approved users saved'));
-        } else if (WT_Filter::post('deletePreapproved') && WT_Filter::checkCsrf()) {
-            $facebook_username = trim(WT_Filter::post('deletePreapproved', WT_REGEX_USERNAME));
+            FlashMessages::addMessage(I18N::translate('Changes to pre-approved users saved'));
+        } else if (Filter::post('deletePreapproved') && Filter::checkCsrf()) {
+            $facebook_username = trim(Filter::post('deletePreapproved', WT_REGEX_USERNAME));
             if ($facebook_username && isset($preApproved[$facebook_username])) {
                 unset($preApproved[$facebook_username]);
                 $this->setSetting('preapproved', serialize($preApproved));
                 Log::addConfigurationLog("Facebook: Pre-approved Facebook user deleted: $facebook_username");
-                WT_FlashMessages::addMessage(WT_I18N::translate('Pre-approved user "%s" deleted', $facebook_username));
+                FlashMessages::addMessage(I18N::translate('Pre-approved user "%s" deleted', $facebook_username));
             } else {
-                WT_FlashMessages::addMessage(WT_I18N::translate('The pre-approved user "%s" could not be deleted', $facebook_username));
+                FlashMessages::addMessage(I18N::translate('The pre-approved user "%s" could not be deleted', $facebook_username));
             }
         }
 
-        $controller = new WT_Controller_Page();
+        $controller = new PageController();
         $controller
-            ->restrictAccess(\WT\Auth::isAdmin())
+            ->restrictAccess(Auth::isAdmin())
             ->setPageTitle($this->getTitle())
             ->pageHeader();
 
@@ -176,28 +187,32 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
         }
 
         $unlinkedOptions = $this->user_options($unlinkedUsers);
-
-        require_once WT_ROOT.'includes/functions/functions_edit.php';
+        
         require 'templates/admin.php';
     }
 
     private function appendPreapproved(&$preApproved, $facebook_username, $row) {
         $facebook_username = $this->cleanseFacebookUsername($facebook_username);
         if (!$facebook_username) {
-            WT_FlashMessages::addMessage(WT_I18N::translate('Missing Facebook username'));
+            FlashMessages::addMessage(I18N::translate('Missing Facebook username'));
             return;
         }
         if ($this->get_user_id_from_facebook_username($facebook_username)) {
-            WT_FlashMessages::addMessage(WT_I18N::translate('User is already registered'));
+            FlashMessages::addMessage(I18N::translate('User is already registered'));
             return;
         }
 
         $preApproved[$facebook_username] = array();
         foreach ($row as $gedcom => $settings) {
+            var_dump($row);
             $preApproved[$facebook_username][$gedcom] = array(
-                                                              'rootid' => filter_var(@$settings['rootid'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' .  WT_REGEX_XREF . ')$/u'))),
-                                                              'gedcomid' => filter_var(@$settings['gedcomid'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' . WT_REGEX_XREF . ')$/u'))),
-                                                              'canedit' => filter_var($settings['canedit'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' . WT_REGEX_ALPHA . ')$/u')))
+                'rootid' => array_key_exists('rootid', $settings)
+                    ? filter_var($settings['rootid'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' .  WT_REGEX_XREF . ')$/u')))
+                    : NULL,
+                'gedcomid' => array_key_exists('gedcomid', $settings)
+                    ? filter_var($settings['gedcomid'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' . WT_REGEX_XREF . ')$/u')))
+                    : NULL,
+                'canedit' => filter_var($settings['canedit'], FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => '/^(' . WT_REGEX_ALPHA . ')$/u')))
             );
         }
     }
@@ -212,9 +227,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
     }
 
     private function connect() {
-        global $WT_SESSION;
-
-        $url = WT_Filter::post('url', NULL, WT_Filter::get('url', NULL, ''));
+        $url = Filter::post('url', NULL, Filter::get('url', NULL, ''));
         // If we’ve clicked login from the login page, we don’t want to go back there.
         if (strpos($url, 'login.php') === 0
             || (strpos($url, 'mod=facebook') !== false
@@ -223,7 +236,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
         }
 
         // Redirect to the homepage/$url if the user is already logged-in.
-        if ($WT_SESSION->wt_user) {
+        if (Auth::check()) {
             header('Location: ' . WT_SCRIPT_PATH . $url);
             exit;
         }
@@ -233,46 +246,45 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
         $connect_url = $this->getConnectURL($url);
 
         if (!$app_id || !$app_secret) {
-            $this->error_page(WT_I18N::translate('Facebook logins have not been setup by the administrator.'));
+            $this->error_page(I18N::translate('Facebook logins have not been setup by the administrator.'));
             return;
         }
 
-        $code = @$_REQUEST["code"];
+        if (isset($_REQUEST['code']))
+            $code = @$_REQUEST["code"];
 
         if (!empty($_REQUEST['error'])) {
-            Log::addErrorLog('Facebook Error: ' . WT_Filter::get('error') . '. Reason: ' . WT_Filter::get('error_reason'));
+            Log::addErrorLog('Facebook Error: ' . Filter::get('error') . '. Reason: ' . Filter::get('error_reason'));
             if ($_REQUEST['error_reason'] == 'user_denied') {
-                $this->error_page(WT_I18N::translate('You must allow access to your Facebook account in order to login with Facebook.'));
+                $this->error_page(I18N::translate('You must allow access to your Facebook account in order to login with Facebook.'));
             } else {
-                $this->error_page(WT_I18N::translate('An error occurred trying to log you in with Facebook.'));
+                $this->error_page(I18N::translate('An error occurred trying to log you in with Facebook.'));
             }
-        } else if (empty($code) && empty($WT_SESSION->facebook_access_token)) {
-            if (!WT_Filter::checkCsrf()) {
-                echo WT_I18N::translate('This form has expired.  Try again.');
+        } else if (empty($code) && !Session::has('facebook_access_token')) {
+            if (!Filter::checkCsrf()) {
+                echo I18N::translate('This form has expired.  Try again.');
                 return;
             }
 
-            $WT_SESSION->timediff = WT_Filter::postInteger('timediff', -43200, 50400, 0); // Same range as date('Z')
+            Session::put('timediff', Filter::postInteger('timediff', -43200, 50400, 0)); // Same range as date('Z')
             // FB Login flow has not begun so redirect to login dialog.
-            $WT_SESSION->facebook_state = md5(uniqid(rand(), TRUE)); // CSRF protection
+            Session::put('facebook_state', md5(uniqid(rand(), TRUE))); // CSRF protection
             $dialog_url = "https://www.facebook.com/dialog/oauth?client_id="
                 . $app_id . "&redirect_uri=" . urlencode($connect_url) . "&state="
-                . $WT_SESSION->facebook_state . "&scope=" . self::scope;
-            Zend_Session::writeClose();
+                . Session::get('facebook_state') . "&scope=" . self::scope;
             echo("<script> window.location.href='" . $dialog_url . "'</script>");
-        } else if (!empty($WT_SESSION->facebook_access_token)) {
+        } else if (Session::has('facebook_access_token')) {
             // User has already authorized the app and we have a token so get their info.
             $graph_url = "https://graph.facebook.com/" . self::api_dir . "me?access_token="
-                . $WT_SESSION->facebook_access_token;
+                . Session::get('facebook_access_token');
             $response = $this->fetch_url($graph_url);
             if ($response === FALSE) {
                 Log::addErrorLog("Facebook: Access token is no longer valid");
                 // Clear the state and try again with a new token.
                 try {
-                    unset($WT_SESSION->facebook_access_token);
-                    unset($WT_SESSION->facebook_state);
-                    Zend_Session::writeClose();
-                } catch (Exception $e) { }
+                    Session::forget('facebook_access_token');
+                    Session::forget('facebook_state');
+                } catch (Exception $e) { echo "oh snap"; }
 
                 header("Location: " . $this->getConnectURL($url));
                 exit;
@@ -280,7 +292,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
 
             $user = json_decode($response);
             $this->login_or_register($user, $url);
-        } else if (!empty($WT_SESSION->facebook_state) && ($WT_SESSION->facebook_state === $_REQUEST['state'])) {
+        } else if (Session::has('facebook_state') && (Session::get('facebook_state') === $_REQUEST['state'])) {
             // User has already been redirected to login dialog.
             // Exchange the code for an access token.
             $token_url = "https://graph.facebook.com/" . self::api_dir . "oauth/access_token?"
@@ -290,44 +302,38 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
             $response = $this->fetch_url($token_url);
             if ($response === FALSE) {
                 Log::addErrorLog("Facebook: Couldn't exchange the code for an access token");
-                $this->error_page(WT_I18N::translate("Your Facebook code is invalid. This can happen if you hit back in your browser after login or if Facebook logins have been setup incorrectly by the administrator."));
+                $this->error_page(I18N::translate("Your Facebook code is invalid. This can happen if you hit back in your browser after login or if Facebook logins have been setup incorrectly by the administrator."));
             }
             $params = null;
             parse_str($response, $params);
             if (empty($params['access_token'])) {
                 Log::addErrorLog("Facebook: The access token was empty");
-                $this->error_page(WT_I18N::translate("Your Facebook code is invalid. This can happen if you hit back in your browser after login or if Facebook logins have been setup incorrectly by the administrator."));
+                $this->error_page(I18N::translate("Your Facebook code is invalid. This can happen if you hit back in your browser after login or if Facebook logins have been setup incorrectly by the administrator."));
             }
 
-            $WT_SESSION->facebook_access_token = $params['access_token'];
+            Session::put('facebook_access_token', $params['access_token']);
 
             $graph_url = "https://graph.facebook.com/" . self::api_dir . "me?access_token="
-                . $WT_SESSION->facebook_access_token;
+                . Session::get('facebook_access_token');
             $meResponse = $this->fetch_url($graph_url);
             if ($meResponse === FALSE) {
-                $this->error_page(WT_I18N::translate("Could not fetch your information from Facebook. Please try again."));
+                $this->error_page(I18N::translate("Could not fetch your information from Facebook. Please try again."));
             }
             $user = json_decode($meResponse);
             $this->login_or_register($user, $url);
         } else {
-            $this->error_page(WT_I18N::translate("The state does not match. You may been tricked to load this page."));
+            $this->error_page(I18N::translate("The state does not match. You may been tricked to load this page."));
         }
     }
 
     private function fetch_url($url) {
         try {
-            $client = new Zend_Http_Client($url,
-                                           array(
-                                                 'keepalive' => true,
-                                                 'storeresponse' => false
-                                                 )
-                                           );
-            $response = $client->request();
+            $response = File::fetchUrl($url);
         } catch (Exception $e) {
             Log::addErrorLog($e);
             return false;
         }
-        return $response->isError() ? false : $response->getBody();
+        return $response;
     }
 
     private function hidden_input($name, $value) {
@@ -343,20 +349,20 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
     }
 
     private function get_users_with_module_settings() {
-	$sql=
-		"SELECT u.user_id, user_name, real_name, email, facebook_username.setting_value as facebook_username".
-		" FROM `##user` u".
-		" LEFT JOIN `##user_setting` facebook_username ON (u.user_id = facebook_username.user_id AND facebook_username.setting_name='facebook_username')".
-                " WHERE u.user_id > 0".
-                " ORDER BY user_name ASC";
-	return WT_DB::prepare($sql)->execute()->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP);
+        $sql=
+            "SELECT u.user_id, user_name, real_name, email, facebook_username.setting_value as facebook_username".
+            " FROM `##user` u".
+            " LEFT JOIN `##user_setting` facebook_username ON (u.user_id = facebook_username.user_id AND facebook_username.setting_name='facebook_username')".
+                    " WHERE u.user_id > 0".
+                    " ORDER BY user_name ASC";
+        return Database::prepare($sql)->execute()->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP);
     }
 
     private function get_user_id_from_facebook_username($facebookUsername) {
-        $statement = WT_DB::prepare(
-                                    "SELECT SQL_CACHE user_id FROM `##user_setting` WHERE setting_name=? AND setting_value=?"
-                                   );
-	return $statement->execute(array(self::user_setting_facebook_username, $this->cleanseFacebookUsername($facebookUsername)))->fetchOne();
+        $statement = Database::prepare(
+            "SELECT SQL_CACHE user_id FROM `##user_setting` WHERE setting_name=? AND setting_value=?"
+           );
+        return $statement->execute(array(self::user_setting_facebook_username, $this->cleanseFacebookUsername($facebookUsername)))->fetchOne();
     }
 
     private function facebookProfileLink($username) {
@@ -370,52 +376,51 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
     }
 
     private function getConnectURL($returnTo='') {
-        return WT_SERVER_NAME . WT_SCRIPT_PATH . "module.php?mod=" . $this->getName()
+        return WT_BASE_URL . "module.php?mod=" . $this->getName()
             . "&mod_action=connect" . ($returnTo ? "&url=" . urlencode($returnTo) : ""); // Workaround FB bug where "&url=" (empty value) prevents OAuth
     }
 
     private function fetchFriendList() {
-        global $WT_SESSION, $controller;
-
-        $controller = new WT_Controller_Page();
+        $controller = new PageController();
 
         $controller->addInlineJavaScript("
-            $('head').append('<link rel=\"stylesheet\" href=\"".WT_MODULES_DIR . $this->getName() . "/facebook.css?v=" . WT_FACEBOOK_VERSION."\" />');",
-                                         WT_Controller_Page::JS_PRIORITY_LOW);
+            $('head').append('<link rel=\"stylesheet\" href=\"" . $this->directory . "/facebook.css?v=" . WT_FACEBOOK_VERSION."\" />');",
+            PageController::JS_PRIORITY_LOW);
 
         $preApproved = unserialize($this->getSetting('preapproved'));
 
-        if (WT_Filter::postArray('preApproved') && WT_Filter::checkCsrf()) {
-            $roleRows = WT_Filter::postArray('preApproved');
-            $fbUsernames = WT_Filter::postArray('facebook_username', WT_REGEX_USERNAME);
+        if (Filter::postArray('preApproved') && Filter::checkCsrf()) {
+            $roleRows = Filter::postArray('preApproved');
+            $fbUsernames = Filter::postArray('facebook_username', WT_REGEX_USERNAME);
             foreach($fbUsernames as $facebook_username) {
                 $facebook_username = $this->cleanseFacebookUsername($facebook_username);
                 $this->appendPreapproved($preApproved, $facebook_username, $roleRows);
             }
             $this->setSetting('preapproved', serialize($preApproved));
-            WT_FlashMessages::addMessage(WT_I18N::translate('Users successfully imported from Facebook'));
+            FlashMessages::addMessage(I18N::translate('Users successfully imported from Facebook'));
             header("Location: module.php?mod=" . $this->getName() . "&mod_action=admin");
             exit;
         }
 
-        if (empty($WT_SESSION->facebook_access_token)) {
-            $this->error_page(WT_I18N::translate("You must <a href='%s'>login to the site via Facebook</a> in order to import friends from Facebook", "index.php?logout=1"));
+        if (!Session::has('facebook_access_token')) {
+            $this->error_page(I18N::translate("You must <a href='%s'>login to the site via Facebook</a> in order to import friends from Facebook", "index.php?logout=1"));
         }
-        $graph_url = "https://graph.facebook.com/" . self::api_dir . "me/friends?fields=first_name,last_name,name,username&access_token="
-            . $WT_SESSION->facebook_access_token;
+        
+        $graph_url = "https://graph.facebook.com/" . self::api_dir . "me/friends?fields=first_name,last_name,name,id&access_token="
+            . Session::get('facebook_access_token');
         $friendsResponse = $this->fetch_url($graph_url);
         if ($friendsResponse === FALSE) {
-            $this->error_page(WT_I18N::translate("Could not fetch your friends from Facebook. Note that this feature won't work for Facebook Apps created after 2014-04-30 due to a Facebook policy change."));
+            $this->error_page(I18N::translate("Could not fetch your friends from Facebook. Note that this feature won't work for Facebook Apps created after 2014-04-30 due to a Facebook policy change."));
         }
 
         $controller
-            ->restrictAccess(\WT\Auth::isAdmin())
+            ->restrictAccess(Auth::isAdmin())
             ->setPageTitle($this->getTitle())
             ->pageHeader();
 
         $friends = json_decode($friendsResponse);
         if (empty($friends->data)) {
-            $this->error_page(WT_I18N::translate("No friend data"));
+            $this->error_page(I18N::translate("No friend data"));
             return;
         }
 
@@ -425,13 +430,12 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
 
         usort($friends->data, "nameSort");
         echo "<form id='facebook_friend_list' method='post' action=''>";
-        require_once WT_ROOT.'includes/functions/functions_edit.php'; // for select_edit_control
         $index = 0;
-        foreach (WT_Tree::getAll() as $tree) {
+        foreach (Tree::getAll() as $tree) {
             $class = ($index++ % 2 ? 'odd' : 'even');
-            echo "<label>" . $tree->tree_name_html . " - " .
-                WT_I18N::translate('Role') . help_link('role') . ": " .
-                select_edit_control('preApproved['.$tree->tree_id.'][canedit]',
+            echo "<label>" . $tree->getNameHtml() . " - " .
+                I18N::translate('Role') . FunctionsPrint::helpLink('role') . ": " .
+                FunctionsEdit::selectEditControl('preApproved['.$tree->getTreeId().'][canedit]',
                                     $this->get_edit_options(), NULL, NULL) .
                 "</label>";
       }
@@ -448,16 +452,15 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
                 $facebook_username . "'/>" .
                 $friend->name . "</label>";
         }
-        echo WT_Filter::getCsrf();
+        echo Filter::getCsrf();
         echo "<button>Select Friends</button></form>";
     }
 
     private function login($user_id) {
-        global $WT_SESSION;
         $user = User::find($user_id);
         $user_name = $user->getUserName();
 
-        // Below copied from authenticateUser in authentication.php
+        // Below copied from login.php
         $is_admin=$user->getPreference('canadmin');
         $verified=$user->getPreference('verified');
         $approved=$user->getPreference('verified_by_admin');
@@ -465,12 +468,10 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
             Auth::login($user);
             Log::addAuthenticationLog('Login: ' . Auth::user()->getUserName() . '/' . Auth::user()->getRealName());
 
-            $WT_SESSION->locale    = Auth::user()->getPreference('language');
-            $WT_SESSION->theme_dir = Auth::user()->getPreference('theme');
-            $WT_SESSION->activity_time = WT_TIMESTAMP;
-            $user->setPreference('sessiontime', WT_TIMESTAMP);
-
-            Zend_Session::writeClose();
+            Auth::user()->setPreference('sessiontime', WT_TIMESTAMP);
+            Session::put('locale', Auth::user()->getPreference('language'));
+            Session::put('theme_id', Auth::user()->getPreference('theme'));
+            I18N::init(Auth::user()->getPreference('language'));
 
             return $user_id;
         } elseif (!$is_admin && !$verified) {
@@ -490,10 +491,10 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
      * @param string $url          (optional) URL to redirect to afterwards.
      */
     private function login_or_register(&$facebookUser, $url='') {
-        $REQUIRE_ADMIN_AUTH_REGISTRATION = WT_Site::getPreference('REQUIRE_ADMIN_AUTH_REGISTRATION');
+        $REQUIRE_ADMIN_AUTH_REGISTRATION = Site::getPreference('REQUIRE_ADMIN_AUTH_REGISTRATION');
 
         if ($this->getSetting('require_verified', 1) && empty($facebookUser->verified)) {
-            $this->error_page(WT_I18N::translate('Only verified Facebook accounts are authorized. Please verify your account on Facebook and then try again'));
+            $this->error_page(I18N::translate('Only verified Facebook accounts are authorized. Please verify your account on Facebook and then try again'));
         }
 
         if (empty($facebookUser->username)) {
@@ -502,37 +503,36 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
         $user_id = $this->get_user_id_from_facebook_username($facebookUser->username);
         if (!$user_id) {
             if (!isset($facebookUser->email)) {
-                $this->error_page(WT_I18N::translate('You must grant access to your email address via Facebook in order to use this website. Please uninstall the application on Facebook and try again.'));
+                $this->error_page(I18N::translate('You must grant access to your email address via Facebook in order to use this website. Please uninstall the application on Facebook and try again.'));
             }
             $user = User::findByIdentifier($facebookUser->email);
             if ($user) {
                 $user_id = $user->getUserId();
             }
         }
-
+        
         if ($user_id) { // This is an existing user so log them in if they are approved
-
             $login_result = $this->login($user_id);
             $message = '';
             switch ($login_result) {
-		case -1: // not validated
-		    $message=WT_I18N::translate('This account has not been verified.  Please check your email for a verification message.');
+                case -1: // not validated
+                    $message=I18N::translate('This account has not been verified.  Please check your email for a verification message.');
                     break;
-		case -2: // not approved
-                    $message=WT_I18N::translate('This account has not been approved.  Please wait for an administrator to approve it.');
+                case -2: // not approved
+                    $message=I18N::translate('This account has not been approved.  Please wait for an administrator to approve it.');
                     break;
                 default:
                     $user = User::find($user_id);
                     $user->setPreference(self::user_setting_facebook_username, $this->cleanseFacebookUsername($facebookUser->username));
                     // redirect to the homepage/$url
-                    header('Location: ' . WT_SCRIPT_PATH . $url);
+                    header('Location: ' . WT_BASE_URL . $url);
                     return;
             }
             $this->error_page($message);
         } else { // This is a new Facebook user who may or may not already have a manual account
 
-            if (!WT_Site::getPreference('USE_REGISTRATION_MODULE')) {
-                $this->error_page('<p>' . WT_I18N::translate('The administrator has disabled registrations.') . '</p>');
+            if (!Site::getPreference('USE_REGISTRATION_MODULE')) {
+                $this->error_page('<p>' . I18N::translate('The administrator has disabled registrations.') . '</p>');
             }
 
             // check if the username is already in use
@@ -585,7 +585,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
                             // Use a direct DB query instead of $tree->setUserPreference since we
                             // can't get a reference to the WT_Tree since it checks permissions but
                             // we are trying to give the permissions.
-                            WT_DB::prepare(
+                            Database::prepare(
                                            "REPLACE INTO `##user_gedcom_setting` (user_id, gedcom_id, setting_name, setting_value) VALUES (?, ?, ?, LEFT(?, 255))"
                                            )->execute(array($user->getUserId(),
                                                             $gedcom,
@@ -599,8 +599,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
                 }
 
                 // We need jQuery below
-                global $controller;
-                $controller = new WT_Controller_Page();
+                $controller = new PageController();
                 $controller
                     ->setPageTitle($this->getTitle())
                     ->pageHeader();
@@ -610,7 +609,7 @@ class facebook_WT_Module extends WT_Module implements WT_Module_Config, WT_Modul
                 echo $this->hidden_input("user_name", $wt_username);
                 echo $this->hidden_input("user_password", $password);
                 echo $this->hidden_input("user_hashcode", $hashcode);
-                echo WT_Filter::getCsrf();
+                echo Filter::getCsrf();
                 echo '</form>';
 
                 if ($verifiedByAdmin) {
@@ -621,7 +620,7 @@ function verify_hash_success() {
 }
 
 function verify_hash_failure() {
-  alert("' . WT_I18N::translate("There was an error verifying your account. Contact the site administrator if you are unable to access the site.")  . '");
+  alert("' . I18N::translate("There was an error verifying your account. Contact the site administrator if you are unable to access the site.")  . '");
   window.location = "' . WT_SCRIPT_PATH . '";
 }
 $(document).ready(function() {
@@ -634,29 +633,26 @@ $(document).ready(function() {
 
             } else {
                 Log::addErrorLog("Facebook: Couldn't create the user account");
-                $this->error_page('<p>' . WT_I18N::translate('Unable to create your account.  Please try again.') . '</p>' .
-                                  '<div class="back"><a href="javascript:history.back()">' . WT_I18N::translate('Back') . '</a></div>');
+                $this->error_page('<p>' . I18N::translate('Unable to create your account.  Please try again.') . '</p>' .
+                                  '<div class="back"><a href="javascript:history.back()">' . I18N::translate('Back') . '</a></div>');
             }
         }
     }
 
     private function error_page($message) {
-        global $controller, $WT_SESSION;
-
         try {
-            unset($WT_SESSION->facebook_access_token);
-            unset($WT_SESSION->facebook_state);
-            Zend_Session::writeClose();
-        } catch (Exception $e) { }
+            Session::forget('facebook_access_token');
+            Session::forget('facebook_state');
+        } catch (Exception $e) { echo 'huh what'; }
 
-        $controller = new WT_Controller_Page();
+        $controller = new PageController();
         $controller
             ->setPageTitle($this->getTitle())
             ->pageHeader();
 
         try {
-            WT_FlashMessages::addMessage($message);
-        } catch (Zend_Session_Exception $zse) {
+            FlashMessages::addMessage($message);
+        } catch (Exception $zse) {
             echo '<div class="warning">'.$message.'</div>';
         }
         exit;
@@ -665,7 +661,7 @@ $(document).ready(function() {
     private function print_findindi_link($element_id, $indiname='', $gedcomTitle=WT_GEDURL) {
 	return '<a href="#" tabindex="-1"
                    onclick="findIndi(document.getElementById(\''.$element_id.'\'), document.getElementById(\''.$indiname.'\'), \''.$gedcomTitle.'\'); return false;"
-                   class="icon-button_indi" title="'.WT_I18N::translate('Find an individual').'"></a>';
+                   class="icon-button_indi" title="'.I18N::translate('Find an individual').'"></a>';
     }
 
     private function indiField($field, $value='', $gedcomTitle=WT_GEDURL) {
@@ -690,17 +686,17 @@ $(document).ready(function() {
             return null;
         }
 
-        $controller->addExternalJavascript(WT_MODULES_DIR . $this->getName() . '/facebook.js?v=' . WT_FACEBOOK_VERSION);
+        $controller->addExternalJavascript($this->directory . '/facebook.js?v=' . WT_FACEBOOK_VERSION);
         /* Stylesheets added by addExternalStylesheet are never output
         if (method_exists($controller, 'addExternalStylesheet')) {
           $controller->addExternalStylesheet(WT_MODULES_DIR . $this->getName() . '/facebook.css?v=' . WT_FACEBOOK_VERSION); // Only in 1.3.3+
         } else {
          */
           $controller->addInlineJavaScript("
-            var FACEBOOK_LOGIN_TEXT = '" . addslashes(WT_I18N::translate('Login with Facebook')) . "';
-            $('head').append('<link rel=\"stylesheet\" href=\"".WT_MODULES_DIR . $this->getName() . "/facebook.css?v=" . WT_FACEBOOK_VERSION."\" />');" .
+            var FACEBOOK_LOGIN_TEXT = '" . addslashes(I18N::translate('Login with Facebook')) . "';
+            $('head').append('<link rel=\"stylesheet\" href=\"" . $this->directory . "/facebook.css?v=" . WT_FACEBOOK_VERSION."\" />');" .
               ($this->hideStandardForms ? '$(document).ready(function() {$("#login-form[name=\'login-form\'], #register-form").hide();});' : ""),
-            WT_Controller_Page::JS_PRIORITY_NORMAL);
+            PageController::JS_PRIORITY_NORMAL);
         //}
 
           // Use the Facebook profile photo if there isn't an existing photo
@@ -745,3 +741,5 @@ $(document).ready(function() {
     }
 
 }
+
+return new FacebookModule;

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -16,62 +16,69 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-$usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . WT_I18N::translate("Facebook usernames can only contain alphanumeric characters (A-Z, 0-9) or a period") . '"';
+use Fisharebest\Webtrees\Filter;
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Functions\FunctionsEdit;
+use Fisharebest\Webtrees\Functions\FunctionsPrint;
+use Fisharebest\Webtrees\Site;
+use Fisharebest\Webtrees\Tree;
+
+$usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . I18N::translate("Facebook usernames can only contain alphanumeric characters (A-Z, 0-9) or a period") . '"';
 
 ?>
 
 <link rel="stylesheet" href="<?php echo WT_MODULES_DIR . $this->getName(); ?>/facebook.css?v=<?php echo  WT_FACEBOOK_VERSION; ?>" />
 <h3><?php echo $this->getTitle(); ?></h3>
 <div>
-  <strong><?php echo WT_I18N::translate('Version: ')?></strong><?php echo WT_FACEBOOK_VERSION; ?>
+  <strong><?php echo I18N::translate('Version: ')?></strong><?php echo WT_FACEBOOK_VERSION; ?>
   <span id="updateBanner" class="ui-state-highlight"></span>
 </div>
 
 <hr/>
-<h4><?php echo WT_I18N::translate('Facebook API'); ?></h4>
+<h4><?php echo I18N::translate('Facebook API'); ?></h4>
 <form method="post" action="">
-  <?php echo WT_Filter::getCsrf(); ?>
-  <p><?php echo WT_I18N::translate('The App ID and secret can be setup at %s.', '<a href="https://developers.facebook.com/apps">https://developers.facebook.com/apps</a>'); ?></p>
+  <?php echo Filter::getCsrf(); ?>
+  <p><?php echo I18N::translate('The App ID and secret can be setup at %s.', '<a href="https://developers.facebook.com/apps">https://developers.facebook.com/apps</a>'); ?></p>
   <label>
-    <?php echo WT_I18N::translate('App ID:'); ?>
+    <?php echo I18N::translate('App ID:'); ?>
     <input type="text" name="app_id" value="<?php echo $this->getSetting('app_id', ''); ?>" />
   </label>
   <label>
-    <?php echo WT_I18N::translate('App Secret:'); ?>
+    <?php echo I18N::translate('App Secret:'); ?>
     <input type="text" name="app_secret" value="<?php echo $this->getSetting('app_secret', ''); ?>" size="40" />
   </label>
-  <?php if (!WT_Site::getPreference('USE_REGISTRATION_MODULE')) { ?>
-  <p><strong><?php echo WT_I18N::translate('NOTE: New user registration is disabled in Site configuration so only existing users will be able to login.');?></strong></p>
+  <?php if (!Site::getPreference('USE_REGISTRATION_MODULE')) { ?>
+  <p><strong><?php echo I18N::translate('NOTE: New user registration is disabled in Site configuration so only existing users will be able to login.');?></strong></p>
   <?php } ?>
   <p>
     <label>
       <input type="checkbox" name="require_verified" value="1"<?php echo ($this->getSetting('require_verified', 1) ? 'checked="checked" ' : ''); ?> />
-      <?php echo WT_I18N::translate('Require verified Facebook accounts'); ?>
-      <em>(<?php echo WT_I18N::translate('Only disable for testing'); ?>)</em>
+      <?php echo I18N::translate('Require verified Facebook accounts'); ?>
+      <em>(<?php echo I18N::translate('Only disable for testing'); ?>)</em>
     </label>
   </p>
   <p>
     <label>
       <input type="checkbox" name="hide_standard_forms" value="1"<?php echo ($this->getSetting('hide_standard_forms', 0) ? 'checked="checked" ' : ''); ?> />
-      <?php echo WT_I18N::translate('Hide regular log-in and registration forms'); ?>
+      <?php echo I18N::translate('Hide regular log-in and registration forms'); ?>
     </label>
   </p>
-  <p><input type="submit" name="saveAPI" value="<?php echo WT_I18N::translate('Save'); ?>"></p>
+  <p><input type="submit" name="saveAPI" value="<?php echo I18N::translate('Save'); ?>"></p>
 </form>
 
 <hr/>
 
-<h4><?php echo WT_I18N::translate('Linked users');?></h4>
+<h4><?php echo I18N::translate('Linked users');?></h4>
 <form method="post" action="">
-  <?php echo WT_Filter::getCsrf(); ?>
-  <p><?php echo WT_I18N::translate("Associate a webtrees user with a Facebook account."); ?></p>
+  <?php echo Filter::getCsrf(); ?>
+  <p><?php echo I18N::translate("Associate a webtrees user with a Facebook account."); ?></p>
 <table>
   <thead>
     <tr>
-      <th><?php echo WT_I18N::translate('webtrees Username'); ?></th>
-      <th><?php echo WT_I18N::translate('Real name'); ?></th>
-      <th><?php echo WT_I18N::translate('Facebook Account'); ?></th>
-      <th><?php echo WT_I18N::translate('Unlink'); ?></th>
+      <th><?php echo I18N::translate('webtrees Username'); ?></th>
+      <th><?php echo I18N::translate('Real name'); ?></th>
+      <th><?php echo I18N::translate('Facebook Account'); ?></th>
+      <th><?php echo I18N::translate('Unlink'); ?></th>
     </tr>
   </thead>
   <tbody>
@@ -93,7 +100,7 @@ $usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . WT_I18N::trans
     <tr>
       <td colspan="2"><select name="user_id"><?php echo $unlinkedOptions; ?></select></td>
       <td><input type="text" name="facebook_username" required="required" <?php echo $usernameValidationAttrs; ?> /></td>
-      <td><input type="submit" name="addLink" value="<?php echo WT_I18N::translate('Add'); ?>"></td>
+      <td><input type="submit" name="addLink" value="<?php echo I18N::translate('Add'); ?>"></td>
     </tr>
   </tbody>
 </table>
@@ -101,36 +108,36 @@ $usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . WT_I18N::trans
 
 <hr/>
 
-<h4><?php echo WT_I18N::translate('Pre-approve users'); ?></h4>
+<h4><?php echo I18N::translate('Pre-approve users'); ?></h4>
 <form method="post" action="">
-  <?php echo WT_Filter::getCsrf(); ?>
-  <p><?php echo WT_I18N::translate("If you know a user's Facebook username but they don't have an account in webtrees, you can pre-approve one so they can login immediately the first time they visit."); ?></p>
+  <?php echo Filter::getCsrf(); ?>
+  <p><?php echo I18N::translate("If you know a user's Facebook username but they don't have an account in webtrees, you can pre-approve one so they can login immediately the first time they visit."); ?></p>
   <ul>
     <li><a href="?mod=facebook&mod_action=admin_friend_picker">
-      <?php echo WT_I18N::translate("Import from your Facebook friends"); ?>
+      <?php echo I18N::translate("Import from your Facebook friends"); ?>
     </a></li>
   </ul>
-<p><input type="submit" name="savePreapproved" value="<?php echo WT_I18N::translate('Save'); ?>"></p>
+<p><input type="submit" name="savePreapproved" value="<?php echo I18N::translate('Save'); ?>"></p>
 <table id="preapproved">
   <thead>
     <tr>
-      <th rowspan="2"><?php echo WT_I18N::translate('Facebook Account'); ?></th>
+      <th rowspan="2"><?php echo I18N::translate('Facebook Account'); ?></th>
       <?php
         $index = 0;
-        foreach (WT_Tree::getAll() as $tree) {
-          echo '<th colspan="3" class="'.($index++ % 2 ? 'odd' : 'even').'">', $tree->tree_name_html, '</th>';
+        foreach (Tree::getAll() as $tree) {
+          echo '<th colspan="3" class="'.($index++ % 2 ? 'odd' : 'even').'">', $tree->getNameHtml(), '</th>';
         }
       ?>
     </tr>
     <tr>
       <?php
       $index = 0;
-      foreach (WT_Tree::getAll() as $tree) {
+      foreach (Tree::getAll() as $tree) {
         $class = ($index++ % 2 ? 'odd' : 'even');
 ?>
-      <th class="<?php echo $class; ?>"><?php echo WT_I18N::translate('Default individual'), help_link('default_individual'); ?></th>
-      <th class="<?php echo $class; ?>"><?php echo WT_I18N::translate('Individual record'), help_link('useradmin_gedcomid'); ?></th>
-      <th class="<?php echo $class; ?>"><?php echo WT_I18N::translate('Role'), help_link('role'); ?></th>
+      <th class="<?php echo $class; ?>"><?php echo I18N::translate('Default individual'), FunctionsPrint::helpLink('default_individual'); ?></th>
+      <th class="<?php echo $class; ?>"><?php echo I18N::translate('Individual record'), FunctionsPrint::helpLink('useradmin_gedcomid'); ?></th>
+      <th class="<?php echo $class; ?>"><?php echo I18N::translate('Role'), FunctionsPrint::helpLink('role'); ?></th>
 
       <?php } ?>
     </tr>
@@ -140,16 +147,16 @@ $usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . WT_I18N::trans
       <td><input type="text" name="preApproved_new_facebook_username" <?php echo $usernameValidationAttrs; ?> size="18"/></td>
       <?php
         $index = 0;
-        foreach (WT_Tree::getAll() as $tree) {
+        foreach (Tree::getAll() as $tree) {
           $class = ($index++ % 2 ? 'odd' : 'even');
           echo '<td class="'.$class.'">',
-          $this->indiField('preApproved[new]['.$tree->tree_id.'][rootid]',
-                           '', $tree->tree_name_url), '</td>',
+          $this->indiField('preApproved[new]['.$tree->getTreeId().'][rootid]',
+                           '', $tree->getNameUrl()), '</td>',
           '<td class="'.$class.'">',
-          $this->indiField('preApproved[new]['.$tree->tree_id.'][gedcomid]',
-                           '', $tree->tree_name_url), '</td>',
+          $this->indiField('preApproved[new]['.$tree->getTreeId().'][gedcomid]',
+                           '', $tree->getNameUrl()), '</td>',
           '<td class="'.$class.'">',
-          select_edit_control('preApproved[new]['.$tree->tree_id.'][canedit]',
+          FunctionsEdit::selectEditControl('preApproved[new]['.$tree->getTreeId().'][canedit]',
                               $this->get_edit_options(), NULL, NULL), '</td>';
         }
       ?>
@@ -162,17 +169,17 @@ $usernameValidationAttrs = 'pattern="[.a-zA-Z0-9]{5,}" title="' . WT_I18N::trans
 <tr>
       <td nowrap="nowrap">' . $this->facebookProfileLink($fbUsername) . '</td>';
           $index = 0;
-          foreach (WT_Tree::getAll() as $tree) {
+          foreach (Tree::getAll() as $tree) {
             $class = ($index++ % 2 ? 'odd' : 'even');
             echo '<td class="'.$class.'">',
-            $this->indiField('preApproved['.$fbUsername.']['.$tree->tree_id.'][rootid]',
-                             @$details[$tree->tree_id]['rootid'], $tree->tree_name_url), '</td>',
+            $this->indiField('preApproved['.$fbUsername.']['.$tree->getTreeId().'][rootid]',
+                             @$details[$tree->getTreeId()]['rootid'], $tree->getNameUrl()), '</td>',
             '<td class="'.$class.'">',
-            $this->indiField('preApproved['.$fbUsername.']['.$tree->tree_id.'][gedcomid]',
-                             @$details[$tree->tree_id]['gedcomid'], $tree->tree_name_url), '</td>',
+            $this->indiField('preApproved['.$fbUsername.']['.$tree->getTreeId().'][gedcomid]',
+                             @$details[$tree->getTreeId()]['gedcomid'], $tree->getNameUrl()), '</td>',
             '<td class="'.$class.'">',
-            select_edit_control('preApproved['.$fbUsername.']['.$tree->tree_id.'][canedit]',
-                                $this->get_edit_options(), NULL, @$details[$tree->tree_id]['canedit']),
+            FunctionsEdit::selectEditControl('preApproved['.$fbUsername.']['.$tree->getTreeId().'][canedit]',
+                                $this->get_edit_options(), NULL, @$details[$tree->getTreeId()]['canedit']),
 	    '</td>';
           }
           echo '
@@ -196,7 +203,7 @@ function update_check() {
     }).done(function(data) {
         var versions = JSON.parse(data);
         if (versions.latest_version > "<?php echo WT_FACEBOOK_VERSION; ?>") {
-            var updateText = "<?php echo WT_Filter::escapeJs(WT_I18N::translate('An update to this module is available: ')); ?>";
+            var updateText = "<?php echo Filter::escapeJs(I18N::translate('An update to this module is available: ')); ?>";
            $("#updateBanner").html(updateText + "<a href='" + versions.website + "'>" + versions.latest_version + " (" + versions.latest_release_date + ")</a>");
         }
     });


### PR DESCRIPTION
Initial changes required to run the module on webtrees 1.7.x (tested in 1.7.9). It may belong on a different branch while testing continues and could definitely use some review, but it seems to do the trick for now :)  
Zend framework was removed, so the translations code had to be removed. I read somewhere that simply having translations in the /language folder will get automatically loaded and used by the I18n class, but did not test it.